### PR TITLE
Basic windows support

### DIFF
--- a/compile.js
+++ b/compile.js
@@ -1,0 +1,27 @@
+const exec = require('child_process').exec;
+const fs = require('fs');  
+
+const compileCommand = getCompileCommand();
+exec(compileCommand, (err, stdout, stderr) => {
+
+  if (isWin()) {
+    const data = fs.readFileSync('lib/webdsp_c.js', 'utf8');
+    const newData = data.replace(/else\{doRun\(\)\}/g, '$&script.dispatchEvent(doneEvent);');
+    fs.writeFileSync('lib/webdsp_c.js', newData);
+  }
+   
+  console.log(stdout);
+  console.log(stderr);
+});
+
+function getCompileCommand() {
+  if (isWin()) {
+    return 'call cpp/compileWASM.bat';
+  } else {
+    return '. ./cpp/compileWASM.sh';
+  }
+}
+
+function isWin() {
+  return /^win/.test(process.platform);
+}

--- a/cpp/compileWASM.bat
+++ b/cpp/compileWASM.bat
@@ -1,0 +1,14 @@
+set CPP_FUNCS=[^
+'_grayScale', ^
+'_brighten', ^
+'_invert', ^
+'_noise', ^
+'_multiFilter', ^
+'_sobelFilter', ^
+'_convFilter',]
+
+emcc -o ./lib/webdsp_c.js ./cpp/webdsp.cpp -lm -O3^
+ -s WASM=1^
+ -s BINARYEN_IMPRECISE=1^
+ -s EXPORTED_FUNCTIONS="%CPP_FUNCS%"^
+ -s ALLOW_MEMORY_GROWTH=1

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "npm run testCPP",
     "testCPP": "g++ ./test/test.cpp -o ./test/testCpp && ./test/testCpp",
     "testJS": "mocha || true",
-    "compile": "echo \"compiling C/C++ to WASM\" && . ./compileWASM.sh"
+    "compile": "echo \"compiling C/C++ to WASM\" && node compile.js"
   },
   "bin": {
     "get-dsp": "./bin/get-dsp.js"


### PR DESCRIPTION
Basic support for windows. This enables running "npm run compile" on windows. User has to set emscripten environment variables manually.